### PR TITLE
docs: add contributors and star history

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Kumpulan proyek open source Indonesia yang aktif dan bisa langsung dijadikan ref
 - [Daftar Proyek](#daftar-proyek)
 - [Cara Berkontribusi](#cara-berkontribusi)
 - [Lisensi](#lisensi)
+- [Kontributor](#kontributor)
+- [Star History](#star-history)
 
 ## Tentang Daftar
 
@@ -148,3 +150,11 @@ Lihat [CONTRIBUTING.md](CONTRIBUTING.md).
 ## Lisensi
 
 Dokumen dan struktur daftar ini menggunakan MIT License, sedangkan tiap proyek tetap mengikuti lisensi asli masing-masing repositori.
+
+## Kontributor
+
+[![Kontributor](https://contrib.rocks/image?repo=IndopenSource/awesome-indonesia)](https://github.com/IndopenSource/awesome-indonesia/graphs/contributors)
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=IndopenSource/awesome-indonesia&type=Date)](https://www.star-history.com/#IndopenSource/awesome-indonesia&Date)

--- a/scripts/update-readme.py
+++ b/scripts/update-readme.py
@@ -102,6 +102,8 @@ def build_readme(items):
         "- [Daftar Proyek](#daftar-proyek)",
         "- [Cara Berkontribusi](#cara-berkontribusi)",
         "- [Lisensi](#lisensi)",
+        "- [Kontributor](#kontributor)",
+        "- [Star History](#star-history)",
         "",
         "## Tentang Daftar",
         "",
@@ -140,6 +142,14 @@ def build_readme(items):
             "## Lisensi",
             "",
             "Dokumen dan struktur daftar ini menggunakan MIT License, sedangkan tiap proyek tetap mengikuti lisensi asli masing-masing repositori.",
+            "",
+            "## Kontributor",
+            "",
+            "[![Kontributor](https://contrib.rocks/image?repo=IndopenSource/awesome-indonesia)](https://github.com/IndopenSource/awesome-indonesia/graphs/contributors)",
+            "",
+            "## Star History",
+            "",
+            "[![Star History Chart](https://api.star-history.com/svg?repos=IndopenSource/awesome-indonesia&type=Date)](https://www.star-history.com/#IndopenSource/awesome-indonesia&Date)",
         ]
     )
     return "\n".join(rows)


### PR DESCRIPTION
Adds generated contributors avatars and a star history chart to the README. Both sections are emitted by scripts/update-readme.py so scheduled README regeneration preserves them.