### PR TITLE
docs: add UI listing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Kumpulan proyek open source Indonesia yang aktif dan bisa langsung dijadikan ref
 
 Awesome List ini berisi koleksi proyek open source Indonesia yang dapat diakses publik dan tetap dirawat oleh komunitas.
 
+Daftar ini juga tersedia dalam versi UI di [tokengratis.id/opensource](https://www.tokengratis.id/opensource) dan [indopensource.org/projects](https://indopensource.org/projects/).
+
 ## Urutan & Sumber Data
 
 Urutan proyek berdasarkan jumlah **GitHub stars** (descending).

--- a/scripts/update-readme.py
+++ b/scripts/update-readme.py
@@ -152,6 +152,8 @@ def build_readme(items):
         "",
         "Awesome List ini berisi koleksi proyek open source Indonesia yang dapat diakses publik dan tetap dirawat oleh komunitas.",
         "",
+        "Daftar ini juga tersedia dalam versi UI di [tokengratis.id/opensource](https://www.tokengratis.id/opensource) dan [indopensource.org/projects](https://indopensource.org/projects/).",
+        "",
         "## Urutan & Sumber Data",
         "",
         "Urutan proyek berdasarkan jumlah **GitHub stars** (descending).",


### PR DESCRIPTION
## What changed

- Add links in README explaining that the catalog is also available as UI listings at:
  - https://www.tokengratis.id/opensource
  - https://indopensource.org/projects/
- Update `scripts/update-readme.py` so the links are preserved when README is regenerated.

## Validation

- `GITHUB_TOKEN=$(gh auth token) make check`
- Validated 48 repositories.
- README regenerated successfully.
- Markdown lint passed.