### PR TITLE
chore: sync missing repos from indopensource stars

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -59,5 +59,13 @@
   "wauputr4/bansos",
   "wauputr4/hermex",
   "wauputr4/skill-bansos",
-  "xpajonx/openempiric"
+  "xpajonx/openempiric",
+  "Aofsnorth/Artidor",
+  "adenaufal/anti-slop-writing",
+  "galpratama/agent-cli",
+  "mallexibra-dev/clipforge",
+  "mmenghancurkan/dynaQRIS",
+  "njinlabs/njinattend-backend",
+  "sipamungkas/subtrack",
+  "wauputr4/agent-proxmox"
 ]


### PR DESCRIPTION
## Summary
- Added 8 missing repositories from the public IndopenSource stars list:
  - Aofsnorth/Artidor
  - adenaufal/anti-slop-writing
  - galpratama/agent-cli
  - mallexibra-dev/clipforge
  - mmenghancurkan/dynaQRIS
  - njinlabs/njinattend-backend
  - sipamungkas/subtrack
  - wauputr4/agent-proxmox

## Note
- Per project contribution docs, only `repos.json` is updated. README will be regenerated automatically by CI workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended the repository list in the system configuration by adding nine additional GitHub repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->