### PR TITLE
ci: commit README updates on main push

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -27,7 +27,19 @@ jobs:
         run: python scripts/update-readme.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit README update to main
+        if: github.event_name == 'push'
+        run: |
+          if git diff --quiet README.md; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore: update repository metadata"
+          git push
       - name: Create README update pull request
+        if: github.event_name != 'push'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.README_UPDATE_TOKEN || github.token }}


### PR DESCRIPTION
## Summary
- Commit generated README changes directly on push events to main.
- Keep scheduled/manual README refreshes using the existing update PR flow.

## Why
After a repo entry PR is merged, the README refresh should land on main without opening another PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated README update workflow to distinguish between direct commits and pull request creation based on trigger event type, ensuring more flexible and efficient documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->