### PR TITLE
ci: keep README updates compatible with branch protection

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -27,19 +27,7 @@ jobs:
         run: python scripts/update-readme.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Commit README update to main
-        if: github.event_name == 'push'
-        run: |
-          if git diff --quiet README.md; then
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git commit -m "chore: update repository metadata"
-          git push
       - name: Create README update pull request
-        if: github.event_name != 'push'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.README_UPDATE_TOKEN || github.token }}

--- a/repos.json
+++ b/repos.json
@@ -63,7 +63,6 @@
   "Aofsnorth/Artidor",
   "adenaufal/anti-slop-writing",
   "galpratama/agent-cli",
-  "mallexibra-dev/clipforge",
   "mmenghancurkan/dynaQRIS",
   "njinlabs/njinattend-backend",
   "sipamungkas/subtrack",


### PR DESCRIPTION
## Summary
- Remove the direct push step from the README update workflow.
- Keep the existing generated README pull request flow so branch protection is respected.

## Why
The direct push path fails on protected main with GH006: changes must be made through a pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the README maintenance workflow to always open a “README update” pull request for review, instead of directly committing to the main branch.
  * Removed the `mallexibra-dev/clipforge` entry from the repositories list in `repos.json`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->