### PR TITLE
chore: remove clipforge pending original PR

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -63,7 +63,6 @@
   "Aofsnorth/Artidor",
   "adenaufal/anti-slop-writing",
   "galpratama/agent-cli",
-  "mallexibra-dev/clipforge",
   "mmenghancurkan/dynaQRIS",
   "njinlabs/njinattend-backend",
   "sipamungkas/subtrack",


### PR DESCRIPTION
## Summary
- Remove `mallexibra-dev/clipforge` from `repos.json` so PR #30 can remain the source of that entry.

## Note
- README is intentionally untouched. The README update workflow should handle it after this lands.
